### PR TITLE
Fix/up testtimeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  node:
+    build: ./node
+    ports:
+      - "3000:3000"
+
+  java:
+    build: ./java
+    ports:
+      - "5100:5100"
+    environment:
+      PORT: 5100

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testTimeout: 30 * 1000 // Set timeout to 30 seconds to allow heroku enough time to start up
 };


### PR DESCRIPTION
Due to how Heroku spins up dynos, the node testing seems to break, this increases timeout to 30 seconds