### PR TITLE
use openjdk:17-slim instead in order to support ARM arch

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -11,7 +11,7 @@ COPY src /javatester/src
 
 RUN ./gradlew bootJar
 
-FROM eclipse-temurin:17-jre-alpine
+FROM openjdk:17-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Had trouble running `docker compose up` using ARM arch on my M1 with `eclipse-temurin:17-jre-alpine`.
This change makes it possible to run it successfully.