### PR TITLE
add dotnet SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ python/venv
 python/__pycache__
 .vscode/
 .idea
+bin
+obj
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test:node": "SDK=node yarn jest",
     "test:java": "SDK=java yarn jest",
     "test:python": "SDK=python yarn jest",
-    "test:go": "SDK=go yarn jest"
+    "test:go": "SDK=go yarn jest",
+    "test:dotnet": "SDK=dotnet yarn jest"
   },
   "devDependencies": {
     "@types/got": "^9.6.12",

--- a/src/all-against-mock.yaml
+++ b/src/all-against-mock.yaml
@@ -6,6 +6,8 @@ sdks:
   - type: python
   - type: node
   - type: java
+  - type: go
+  - type: dotnet
 tests:
   load: 
     file: '@unleash/client-specification/specifications/index.json'

--- a/src/all-against-oss.yaml
+++ b/src/all-against-oss.yaml
@@ -1,0 +1,15 @@
+adminToken: '*:*.unleash-insecure-admin-api-token'
+clientToken: '*:development.unleash-insecure-api-token'
+servers: 
+  - type: OSSServer
+    image: unleashorg/unleash-server:latest
+    postgresImage: postgres:alpine3.15
+sdks:
+  - type: python
+  - type: node
+  - type: java
+  - type: go
+  - type: dotnet
+tests:
+  load: 
+    file: '@unleash/client-specification/specifications/index.json'

--- a/src/all-config.yaml
+++ b/src/all-config.yaml
@@ -8,6 +8,7 @@ servers:
 sdks:
   - type: node
   - type: go
+  - type: dotnet
   - type: python
     excluding:
       - '12' # Fails on Python - Not supported on this SDK?

--- a/src/dotnet.yaml
+++ b/src/dotnet.yaml
@@ -1,0 +1,13 @@
+adminToken: '*:*.unleash-insecure-admin-api-token'
+clientToken: '*:development.unleash-insecure-api-token'
+servers: 
+  - type: OSSServer
+sdks:
+  - type: dotnet
+tests:
+  load: 
+    file: '@unleash/client-specification/specifications/index.json'
+    excluding: 
+      - '13'
+      - '14'
+      - '15'

--- a/src/from-config.test.ts
+++ b/src/from-config.test.ts
@@ -1,60 +1,73 @@
 import specs from '@unleash/client-specification/specifications/index.json'
 import got from 'got'
-import YAML from 'yaml';
-import fs from 'fs';
+import YAML from 'yaml'
+import fs from 'fs'
+import { Network, StartedNetwork } from 'testcontainers'
 import {
-  Network,
-  StartedNetwork,
-} from 'testcontainers';
-import { MockServerConfig, OSSServerConfig, parseResult, TestConfiguration, TestYamlConfig } from './lib/Config'
-import { ContainerInstance, UnleashServerInterface } from './lib/BaseContainers';
-import { SDKOptions } from './lib/SDKContainers';
+  MockServerConfig,
+  OSSServerConfig,
+  parseResult,
+  TestConfiguration,
+  TestYamlConfig
+} from './lib/Config'
+import { ContainerInstance, UnleashServerInterface } from './lib/BaseContainers'
+import { SDKOptions } from './lib/SDKContainers'
 
-const rawConfig = fs.readFileSync(`./src/${process.env.CONFIG || 'all-against-mock'}.yaml`, 'utf8');
-const parsedConfig = YAML.parse(rawConfig) as TestYamlConfig;
+const rawConfig = fs.readFileSync(
+  `./src/${process.env.CONFIG || 'all-against-mock'}.yaml`,
+  'utf8'
+)
+const parsedConfig = YAML.parse(rawConfig) as TestYamlConfig
 
-const sdks = parsedConfig.sdks.map(c => {
-  c.name = c.name || c.type;
-  return c
-})
+const sdks = process.env.SDK
+  ? [{ name: process.env.SDK, type: process.env.SDK }]
+  : parsedConfig.sdks.map(c => {
+      c.name = c.name || c.type
+      return c
+    })
+
+const servers = process.env.SERVER
+  ? [{ type: process.env.SERVER }]
+  : parsedConfig.servers
 
 const testDetails = parsedConfig.tests.load
 
 const excludeTests = testDetails.excluding || []
 
-
-function parseConfig(server: OSSServerConfig | MockServerConfig): TestConfiguration {
+function parseConfig(
+  server: OSSServerConfig | MockServerConfig
+): TestConfiguration {
   let config: TestConfiguration
   if (server.type === 'OSSServer') {
     const ossServer = server as OSSServerConfig
     config = {
       serverImpl: ossServer.type,
-      postgres:{
-        image: ossServer.postgresImage,
+      postgres: {
+        image: ossServer.postgresImage ?? 'postgres:alpine3.15',
         dbName: 'unleash',
         user: 'unleash_user',
-        password: 'unleash.the.password',
+        password: 'unleash.the.password'
       },
       unleash: {
-        image: ossServer.image,
+        image: ossServer.image ?? 'unleashorg/unleash-server:latest',
         clientToken: parsedConfig.clientToken,
-        adminToken: parsedConfig.adminToken,
+        adminToken: parsedConfig.adminToken
       }
     }
   } else if (server.type === 'MockServer' || server.type === 'Edge') {
     // This is pointless, we should remove TestConfiguration
     config = {
       serverImpl: server.type,
-      postgres:{
+      postgres: {
         image: '',
         dbName: '',
         user: '',
-        password: '',
+        password: ''
       },
       unleash: {
         image: '',
         clientToken: parsedConfig.clientToken,
-        adminToken: parsedConfig.adminToken,
+        adminToken: parsedConfig.adminToken
       }
     }
   } else {
@@ -63,92 +76,98 @@ function parseConfig(server: OSSServerConfig | MockServerConfig): TestConfigurat
   return config
 }
 
-const tests: string[] = specs.filter(spec => !excludeTests.includes(spec.slice(0, 2)))
+const tests: string[] = specs.filter(
+  spec => !excludeTests.includes(spec.slice(0, 2))
+)
 
-describe.each(parsedConfig.servers)(`$type`, (server) => {
+describe.each(servers)(`$type`, server => {
   let unleashServer: ContainerInstance & UnleashServerInterface
   let network: StartedNetwork
   let initialized = false
   let sdkContainers = new Map<string, ContainerInstance>()
   let config = parseConfig(server)
-describe.each(tests)(`%s suite`, (testName) => {
-  // eslint-disable-next-line
-  const definition: ISpecDefinition = require(`@unleash/client-specification/specifications/${testName}`)
+  describe.each(tests)(`%s suite`, testName => {
+    // eslint-disable-next-line
+    const definition: ISpecDefinition = require(`@unleash/client-specification/specifications/${testName}`)
 
-  beforeAll(async () => {
-    if (!initialized){
-      console.log(`===== Initializing Unleash ${server.type} ${definition.name} =====`)
-      network = await new Network().start()
-      unleashServer = require('./servers/index').create(config, network)
-      await unleashServer.initialize()
-      initialized = true
-    } else {
-      console.log(`===== Reseting Unleash ${server.type} before ${definition.name} =====`)
-      await unleashServer.reset()
-    }
-
-    // ========= set unleash state (~50ms)
-    let succeed = await unleashServer.setState(definition.state)
-    expect(succeed).toBeTruthy()
-  })
-    
-  describe.each(sdks)(`$name SDK`, (sdkTestConfig) => {
-    const excludedForSDK = sdkTestConfig.excluding || []
-    if (excludedForSDK.filter(s => testName.startsWith(s)).length > 0) {
-      return;
-    }
-    let sdkUrl: string
-    
     beforeAll(async () => {
-      let sdkContainer = sdkContainers.get(sdkTestConfig.type)
-      if (!sdkContainer) {
-        // console.log(`===== Initializing ${sdk} =====`)
-        let options: SDKOptions = {
-          unleashApiUrl: `http://${unleashServer.getInternalIpAddress()}:${unleashServer.getInternalPort()}/api`,
-          apiToken: config.unleash.adminToken,
-          network: network,
-          sdkImpl: sdkTestConfig.client
-        }
-        let { create } = require(`./sdks/${sdkTestConfig.type}/container`)
-        sdkContainer = create(options) as ContainerInstance
-        await sdkContainer.initialize()
-        sdkContainers.set(sdkTestConfig.name!, sdkContainer)
+      if (!initialized) {
+        console.log(
+          `===== Initializing Unleash ${server.type} ${definition.name} =====`
+        )
+        network = await new Network().start()
+        unleashServer = require('./servers/index').create(config, network)
+        await unleashServer.initialize()
+        initialized = true
       } else {
-        // cleanup cached SDK state
-        // console.log(`===== Reseting state of ${sdk} =====`)
-        await sdkContainer.reset()
+        console.log(
+          `===== Reseting Unleash ${server.type} before ${definition.name} =====`
+        )
+        await unleashServer.reset()
       }
-      sdkUrl = `http://localhost:${sdkContainer.getMappedPort()}`
+
+      // ========= set unleash state (~50ms)
+      let succeed = await unleashServer.setState(definition.state)
+      expect(succeed).toBeTruthy()
     })
 
-    if (definition.tests) {
-      test.each(definition.tests)(`$description`, async (testCase) => {
-        const { body, statusCode } = await got.post(`${sdkUrl}/is-enabled`, {
-          json: {
-            toggle: testCase.toggleName,
-            context: testCase.context
-          }
-        })
-        expect(statusCode).toBe(200)
-        const result: EnabledResult = JSON.parse(body)
-        expect(result.enabled).toBe(testCase.expectedResult)
-      })
-    }
+    describe.each(sdks)(`$name SDK`, sdkTestConfig => {
+      const excludedForSDK = sdkTestConfig.excluding || []
+      if (excludedForSDK.filter(s => testName.startsWith(s)).length > 0) {
+        return
+      }
+      let sdkUrl: string
 
-    if (definition.variantTests) {
-      test.each(definition.variantTests)(`$description`, async (testCase) => {
-        const { body, statusCode } = await got.post(`${sdkUrl}/variant`, {
-          json: {
-            toggle: testCase.toggleName,
-            context: testCase.context
+      beforeAll(async () => {
+        let sdkContainer = sdkContainers.get(sdkTestConfig.type)
+        if (!sdkContainer) {
+          // console.log(`===== Initializing ${sdk} =====`)
+          let options: SDKOptions = {
+            unleashApiUrl: `http://${unleashServer.getInternalIpAddress()}:${unleashServer.getInternalPort()}/api`,
+            apiToken: config.unleash.adminToken,
+            network: network,
+            sdkImpl: sdkTestConfig.client
           }
-        })
-        expect(statusCode).toBe(200)
-        const variantResult: VariantResult = JSON.parse(body)
-        const result = parseResult(sdkTestConfig.name!, variantResult)
-        expect(result).toEqual(testCase.expectedResult)
+          let { create } = require(`./sdks/${sdkTestConfig.type}/container`)
+          sdkContainer = create(options) as ContainerInstance
+          await sdkContainer.initialize()
+          sdkContainers.set(sdkTestConfig.name!, sdkContainer)
+        } else {
+          // cleanup cached SDK state
+          // console.log(`===== Reseting state of ${sdk} =====`)
+          await sdkContainer.reset()
+        }
+        sdkUrl = `http://localhost:${sdkContainer.getMappedPort()}`
       })
-    }
+
+      if (definition.tests) {
+        test.each(definition.tests)(`$description`, async testCase => {
+          const { body, statusCode } = await got.post(`${sdkUrl}/is-enabled`, {
+            json: {
+              toggle: testCase.toggleName,
+              context: testCase.context
+            }
+          })
+          expect(statusCode).toBe(200)
+          const result: EnabledResult = JSON.parse(body)
+          expect(result.enabled).toBe(testCase.expectedResult)
+        })
+      }
+
+      if (definition.variantTests) {
+        test.each(definition.variantTests)(`$description`, async testCase => {
+          const { body, statusCode } = await got.post(`${sdkUrl}/variant`, {
+            json: {
+              toggle: testCase.toggleName,
+              context: testCase.context
+            }
+          })
+          expect(statusCode).toBe(200)
+          const variantResult: VariantResult = JSON.parse(body)
+          const result = parseResult(sdkTestConfig.name!, variantResult)
+          expect(result).toEqual(testCase.expectedResult)
+        })
+      }
+    })
   })
-})
 })

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -1,62 +1,71 @@
 export interface PostgresConfig {
-    image: string,
-    dbName: string,
-    user: string,
-    password: string,
+  image: string
+  dbName: string
+  user: string
+  password: string
 }
 
 export interface UnleashConfig {
-    image: string,
-    clientToken: string,
-    adminToken: string,
+  image: string
+  clientToken: string
+  adminToken: string
 }
 export interface TestConfiguration {
-    serverImpl?: string,
-    postgres: PostgresConfig,
-    unleash: UnleashConfig,
+  serverImpl?: string
+  postgres: PostgresConfig
+  unleash: UnleashConfig
 }
 
 export interface OSSServerConfig {
-    type: string,
-    image: string,
-    postgresImage: string,
+  type: string
+  image: string
+  postgresImage: string
 }
 export interface MockServerConfig {
-    type: string,
+  type: string
 }
 // should replace TestConfiguration
 export interface TestYamlConfig {
-    clientToken: string,
-    adminToken: string,
-    servers: (OSSServerConfig | MockServerConfig)[],
-    sdks: {
-        name?: string, // define an alternative name instead of type
-        type: string,
-        excluding?: string[],
-        client?: string
-    }[],
-    tests: {
-        load: {
-            file: string,
-            excluding?: string[]
-        }
-    },
+  clientToken: string
+  adminToken: string
+  servers: (OSSServerConfig | MockServerConfig)[]
+  sdks: {
+    name?: string // define an alternative name instead of type
+    type: string
+    excluding?: string[]
+    client?: string
+  }[]
+  tests: {
+    load: {
+      file: string
+      excluding?: string[]
+    }
+  }
 }
 
 // Needed because of slight inconsistencies in the results we get back from the different SDKs
 // We should probably fix the SDKs to return the same result type in the future...
 export const parseResult = (sdk: string, variantResult: VariantResult) => {
-    // Destructured because some of the SDKs return extra properties we don't have on expectedResult:
-    // Python: weightType
-    // Java: stickiness
-    const { name, enabled, payload } = variantResult.enabled
-    let result = { name, enabled, payload }
-    // This handles a case where the Java SDK sends a payload with a null value, where we are not expecting a payload at all in that case
-    if (payload?.value === null) {
-      console.warn(
-        `${sdk}: Payload value is null, removing payload from result`
-      )
-      result = { name, enabled, payload: undefined }
-    }
-    return result
+  // Destructured because some of the SDKs return extra properties we don't have on expectedResult:
+  // Python: weightType
+  // Java: stickiness
+  const { name, enabled, payload } = variantResult.enabled
+  let result = { name, enabled, payload }
+  // This handles a case where the Java SDK sends a payload with a null value, where we are not expecting a payload at all in that case
+  if (payload?.value === null) {
+    console.warn(`${sdk}: Payload value is null, removing payload from result`)
+    result = { ...result, payload: undefined }
   }
+  // dotnet: This SDK returns `payload` as null when it is not expected (similar to the Java SDK but `payload` instead of `payload.value`)
+  if (payload === null) {
+    console.warn(`${sdk}: Payload is null, removing payload from result`)
+    result = { ...result, payload: undefined }
+  }
+  // dotnet: This SDK returns `isEnabled` instead of `enabled`, and `payload` as null when it is not expected
+  if ('isEnabled' in variantResult.enabled) {
+    console.warn(`${sdk}: Passing isEnabled to enabled`)
+    // @ts-expect-error
+    result = { ...result, enabled: variantResult.enabled.isEnabled }
+  }
+  return result
+}

--- a/src/only-valid.yaml
+++ b/src/only-valid.yaml
@@ -15,6 +15,7 @@ sdks:
   - type: go
     excluding:
       - '08'
+  - type: dotnet
 tests:
   load: 
     file: '@unleash/client-specification/specifications/index.json'

--- a/src/only-valid.yaml
+++ b/src/only-valid.yaml
@@ -15,7 +15,6 @@ sdks:
   - type: go
     excluding:
       - '08'
-  - type: dotnet
 tests:
   load: 
     file: '@unleash/client-specification/specifications/index.json'

--- a/src/sdks/dotnet/Dockerfile
+++ b/src/sdks/dotnet/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+WORKDIR /app
+
+# Copy everything
+COPY . .
+# Restore as distinct layers
+RUN dotnet restore
+# Build and publish a release
+RUN dotnet publish -o sdk-integration-tester
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine as runtime
+WORKDIR /app
+COPY --from=build /app/sdk-integration-tester .
+EXPOSE 5133
+ENV ASPNETCORE_URLS=http://*:5133
+ENTRYPOINT ["dotnet", "dotnet.dll"]

--- a/src/sdks/dotnet/Dockerfile
+++ b/src/sdks/dotnet/Dockerfile
@@ -6,12 +6,10 @@ COPY . .
 # Restore as distinct layers
 RUN dotnet restore
 # Build and publish a release
-RUN dotnet publish -o sdk-integration-tester
+RUN dotnet publish -o sdk-integration-tester -c Release
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine as runtime
 WORKDIR /app
 COPY --from=build /app/sdk-integration-tester .
-EXPOSE 5133
-ENV ASPNETCORE_URLS=http://*:5133
 ENTRYPOINT ["dotnet", "dotnet.dll"]

--- a/src/sdks/dotnet/Program.cs
+++ b/src/sdks/dotnet/Program.cs
@@ -1,0 +1,59 @@
+using Unleash;
+using Unleash.ClientFactory;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+var port = Environment.GetEnvironmentVariable("PORT") ?? "5133";
+var url = Environment.GetEnvironmentVariable("UNLEASH_URL");
+var apiKey = Environment.GetEnvironmentVariable("UNLEASH_API_TOKEN");
+
+var settings = new UnleashSettings()
+{
+  AppName = "dotnet-test-server",
+  UnleashApi = new Uri(url),
+  CustomHttpHeaders = new Dictionary<string, string>()
+    {
+      {"Authorization", apiKey }
+    },
+};
+
+var unleashFactory = new UnleashClientFactory();
+
+IUnleash unleash = unleashFactory.CreateClient(settings, synchronousInitialization: true);
+
+app.MapGet("/ready", () =>
+{
+  return new
+  {
+    status = "ok"
+  };
+});
+
+app.MapPost("/is-enabled", (IsEnabledBody body) =>
+{
+  return new
+  {
+    name = body.toggle,
+    enabled = unleash.IsEnabled(body.toggle, body.context),
+    context = body.context,
+  };
+});
+
+app.MapPost("/variant", (IsEnabledBody body) =>
+{
+  return new
+  {
+    name = body.toggle,
+    enabled = unleash.GetVariants(body.toggle, body.context).First(),
+    context = body.context
+  };
+});
+
+app.Run();
+
+class IsEnabledBody
+{
+  public string toggle { get; set; }
+  public UnleashContext context { get; set; }
+}

--- a/src/sdks/dotnet/Program.cs
+++ b/src/sdks/dotnet/Program.cs
@@ -45,7 +45,7 @@ app.MapPost("/variant", (IsEnabledBody body) =>
   return new
   {
     name = body.toggle,
-    enabled = unleash.GetVariants(body.toggle, body.context).First(),
+    enabled = unleash.GetVariant(body.toggle, body.context, Unleash.Internal.Variant.DISABLED_VARIANT),
     context = body.context
   };
 });

--- a/src/sdks/dotnet/Program.cs
+++ b/src/sdks/dotnet/Program.cs
@@ -50,7 +50,7 @@ app.MapPost("/variant", (IsEnabledBody body) =>
   };
 });
 
-app.Run();
+app.Run("http://*:" + port);
 
 class IsEnabledBody
 {

--- a/src/sdks/dotnet/Properties/launchSettings.json
+++ b/src/sdks/dotnet/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:34923",
+      "sslPort": 44330
+    }
+  },
+  "profiles": {
+    "dotnet": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7004;http://localhost:5133",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/sdks/dotnet/README.md
+++ b/src/sdks/dotnet/README.md
@@ -1,0 +1,1 @@
+Currently using .NET SDK 6.0 - Minimal API template

--- a/src/sdks/dotnet/appsettings.Development.json
+++ b/src/sdks/dotnet/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/sdks/dotnet/appsettings.json
+++ b/src/sdks/dotnet/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/sdks/dotnet/container.ts
+++ b/src/sdks/dotnet/container.ts
@@ -1,0 +1,7 @@
+const path = require('path')
+import { SDKDockerfileContainer, SDKOptions } from '../../lib/SDKContainers'
+
+export function create(options: SDKOptions) {
+  const buildContext = path.resolve(__dirname, '.')
+  return new SDKDockerfileContainer(buildContext, 5133, options)
+}

--- a/src/sdks/dotnet/dotnet.csproj
+++ b/src/sdks/dotnet/dotnet.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Unleash.Client" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/simple.test.ts
+++ b/src/simple.test.ts
@@ -1,84 +1,140 @@
 import got from 'got'
 
-import { readdirSync, existsSync } from 'fs'
+import fs from 'fs'
+import { Network, StartedNetwork } from 'testcontainers'
 import {
-  Network,
-  StartedNetwork,
-} from 'testcontainers';
-import { TestConfiguration } from './lib/Config'
-import { ContainerInstance, UnleashServerInterface } from './lib/BaseContainers';
-const ADMIN_TOKEN = '*:*.unleash-insecure-admin-api-token'
+  MockServerConfig,
+  OSSServerConfig,
+  TestConfiguration,
+  TestYamlConfig
+} from './lib/Config'
+import { ContainerInstance, UnleashServerInterface } from './lib/BaseContainers'
+import YAML from 'yaml'
+import { SDKOptions } from './lib/SDKContainers'
 
-let config: TestConfiguration = {
-  postgres:{
-    image: 'postgres:alpine3.15',
-    dbName: 'unleash',
-    user: 'unleash_user',
-    password: 'unleash.the.password',
-  },
-  unleash: {
-    image: 'unleashorg/unleash-server:latest',
-    clientToken: '*:development.unleash-insecure-api-token',
-    adminToken: '*:*.unleash-insecure-admin-api-token',
+const rawConfig = fs.readFileSync(
+  `./src/${process.env.CONFIG || 'all-against-mock'}.yaml`,
+  'utf8'
+)
+const parsedConfig = YAML.parse(rawConfig) as TestYamlConfig
+
+const sdks = process.env.SDK
+  ? [{ name: process.env.SDK, type: process.env.SDK }]
+  : parsedConfig.sdks.map(c => {
+      c.name = c.name || c.type
+      return c
+    })
+
+const servers = process.env.SERVER
+  ? [{ type: process.env.SERVER }]
+  : parsedConfig.servers
+
+function parseConfig(
+  server: OSSServerConfig | MockServerConfig
+): TestConfiguration {
+  let config: TestConfiguration
+  if (server.type === 'OSSServer') {
+    const ossServer = server as OSSServerConfig
+    config = {
+      serverImpl: ossServer.type,
+      postgres: {
+        image: ossServer.postgresImage ?? 'postgres:alpine3.15',
+        dbName: 'unleash',
+        user: 'unleash_user',
+        password: 'unleash.the.password'
+      },
+      unleash: {
+        image: ossServer.image ?? 'unleashorg/unleash-server:latest',
+        clientToken: parsedConfig.clientToken,
+        adminToken: parsedConfig.adminToken
+      }
+    }
+  } else if (server.type === 'MockServer' || server.type === 'Edge') {
+    // This is pointless, we should remove TestConfiguration
+    config = {
+      serverImpl: server.type,
+      postgres: {
+        image: '',
+        dbName: '',
+        user: '',
+        password: ''
+      },
+      unleash: {
+        image: '',
+        clientToken: parsedConfig.clientToken,
+        adminToken: parsedConfig.adminToken
+      }
+    }
+  } else {
+    throw new Error(`Invalid server config type ${server.type}`)
   }
+  return config
 }
 
-const getDirectories = (source: string) =>
-  readdirSync(source, { withFileTypes: true })
-    .filter(dirent => dirent.isDirectory())
-    .filter(dirent => existsSync(`${source}/${dirent.name}/container.ts`))
-    .map(dirent => dirent.name)
-    
-const sdks = process.env.SDK? [process.env.SDK] : getDirectories('src/sdks')
-describe("SDK tests", () => {
+describe.each(servers)(`$type`, server => {
   let unleashServer: ContainerInstance & UnleashServerInterface
   let network: StartedNetwork
+  let initialized = false
+  let sdkContainers = new Map<string, ContainerInstance>()
+  let config = parseConfig(server)
 
-  beforeEach(async () => {
-    try {
+  beforeAll(async () => {
+    if (!initialized) {
+      console.log(`===== Initializing Unleash ${server.type} =====`)
       network = await new Network().start()
       unleashServer = require('./servers/index').create(config, network)
       await unleashServer.initialize()
-    } catch (err) {
-      console.log(err)
+      initialized = true
+    } else {
+      console.log(`===== Reseting Unleash ${server.type} =====`)
+      await unleashServer.reset()
     }
-  });
 
-  async function setState(file: string) {
-    // TODO: this is a global state defined for all tests and reseted before each
-    // we need the state to be defined by the test either as a DB state or a json that can be imported
-    const state = require(file)
-    
-    await unleashServer.setState(state)
-  }
+    // ========= set unleash state (~50ms)
+    const state = require('./simple.test.state.json')
+    let succeed = await unleashServer.setState(state)
+    expect(succeed).toBeTruthy()
+  })
 
-  it.each(sdks)('SDK %p', async (sdk: string) => {
-    await setState('./simple.test.state.json')
+  describe.each(sdks)(`$name SDK`, sdkTestConfig => {
+    let sdkUrl: string
 
-    let options = {
-      unleashApiUrl: `http://${unleashServer.getInternalIpAddress()}:${unleashServer.getInternalPort()}/api`,
-      apiToken: ADMIN_TOKEN,
-      network: network
-    }
-    let { create } = require(`./sdks/${sdk}/container`)
-    let sdkContainer: ContainerInstance = create(options)
-    await sdkContainer.initialize()
-    const { body, statusCode } = await got.post(`http://localhost:${sdkContainer.getMappedPort()}/is-enabled`, {
-      headers: {
-        Authorization: ADMIN_TOKEN
-      },
-      json: {
-        toggle: 'test-on',
-        context: {
-          userId: '123'
+    beforeAll(async () => {
+      let sdkContainer = sdkContainers.get(sdkTestConfig.type)
+      if (!sdkContainer) {
+        // console.log(`===== Initializing ${sdk} =====`)
+        let options: SDKOptions = {
+          unleashApiUrl: `http://${unleashServer.getInternalIpAddress()}:${unleashServer.getInternalPort()}/api`,
+          apiToken: config.unleash.adminToken,
+          network: network,
+          sdkImpl: sdkTestConfig.client
         }
+        let { create } = require(`./sdks/${sdkTestConfig.type}/container`)
+        sdkContainer = create(options) as ContainerInstance
+        await sdkContainer.initialize()
+        sdkContainers.set(sdkTestConfig.name!, sdkContainer)
+      } else {
+        // cleanup cached SDK state
+        // console.log(`===== Reseting state of ${sdk} =====`)
+        await sdkContainer.reset()
       }
+      sdkUrl = `http://localhost:${sdkContainer.getMappedPort()}`
     })
-    console.log(body)
-    expect(statusCode).toBe(200)
-    let res = JSON.parse(body)
-    expect(res.name).toBe('test-on')
-    expect(res.enabled).toBeTruthy()
-    expect(res.context.userId).toBe('123')
-  });
-});
+
+    test('simple test', async () => {
+      const { body, statusCode } = await got.post(`${sdkUrl}/is-enabled`, {
+        json: {
+          toggle: 'test-on',
+          context: {
+            userId: '123'
+          }
+        }
+      })
+      expect(statusCode).toBe(200)
+      const result = JSON.parse(body)
+      expect(result.name).toBe('test-on')
+      expect(result.enabled).toBeTruthy()
+      expect(result.context.userId).toBe('123')
+    })
+  })
+})


### PR DESCRIPTION
https://linear.app/unleash/issue/2-296/net-sdk-tester

 - There's a problem when using this SDK with `MockServer` - https://linear.app/unleash/issue/2-317/bug-mockserver-is-not-working-for-specific-cases - It's documented in that issue and I don't think it should prevent us from merging this, as figuring out the exact problem might take more time;
 - `13`, `14` and `15` fail on OSSServer, but since their description mentions constraints, I assume they may no longer fail in the future with https://github.com/Unleash/unleash/pull/2112;
 - Includes upgrading `simple.test.ts` to be more aligned with the `from-config` tests;
 - This PR also includes better env variable support for tests;
 - Some `dotnet` SDK specifics needed to be added to: https://github.com/Unleash/sdk-integration-tester/blob/067b92b17e7b659a93d564d1f8c2c0c17e1ef8a0/src/lib/Config.ts#L48
 
 You can test this SDK with a specific config: `CONFIG=dotnet yarn test`