### PR TITLE
feat: Properly report ignored tests

### DIFF
--- a/src/lib/TestTypes.ts
+++ b/src/lib/TestTypes.ts
@@ -1,8 +1,12 @@
 
-interface IVariantTest {
+
+interface ITestDef {
     description: string
     context: Record<string, any>
     toggleName: string
+}
+
+interface IVariantTest extends ITestDef {
     expectedResult: {
         name: string
         payload: unknown
@@ -10,10 +14,7 @@ interface IVariantTest {
     }
 }
 
-interface ISpecTest {
-    description: string
-    context: Record<string, any>
-    toggleName: string
+interface ISpecTest extends ITestDef {
     expectedResult: boolean
 }
 

--- a/src/only-valid.yaml
+++ b/src/only-valid.yaml
@@ -6,7 +6,12 @@ sdks:
   - type: node
   - type: python
     excluding:
-      - '09'
+      - 'Feature.constraints.dual should be enabled in prod'
+      - 'Enabled in prod for userId=123'
+      - 'Feature.constraints.custom should be enabled in prod for norway'
+      - 'Feature.constraints.multi should be enabled in prod for user 2'
+      - 'Feature.constraints.list should be enabled in stage environment'
+      - 'Feature.constraints.simple should be enabled in dev environment'
       - '12'
       - '13'
       - '15'


### PR DESCRIPTION
## About the changes
This reports tests as skipped:
![image](https://user-images.githubusercontent.com/455064/196110585-67253bcb-3fd6-42a7-b9b4-10647f95d99b.png)

![image](https://user-images.githubusercontent.com/455064/196110689-1e00df9d-56ec-434c-9a41-7d50b6130887.png)


As an extra, we can now specify individual tests we want to skip rather than the whole suite:
```yaml
    excluding:
      - 'Feature.constraints.dual should be enabled in prod'
      - 'Enabled in prod for userId=123'
      - '15'
```
