### PR TITLE
fix: dotnet sdk, add docker image references

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        config: 
-          #- dotnet # Not working?
+        config:
+          - dotnet
           - only-valid
     steps:
       - uses: actions/checkout@v3

--- a/src/dotnet.yaml
+++ b/src/dotnet.yaml
@@ -2,6 +2,8 @@ adminToken: '*:*.unleash-insecure-admin-api-token'
 clientToken: '*:development.unleash-insecure-api-token'
 servers: 
   - type: OSSServer
+    image: unleashorg/unleash-server:latest
+    postgresImage: postgres:alpine3.15
 sdks:
   - type: dotnet
 tests:


### PR DESCRIPTION
## About the changes
In a previous PR, we removed default image values from the test code, so every configuration detail is controlled by the YAML config file. This change in parallel with enabling the dotnet SDK were not aligned and it caused the dotnet to fail. 

With this change we're able to run dotnet tests