### PR TITLE
Add ability to log http communication between the containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,28 @@ export function create(
 Since SDKs we've defined an ad-hoc one that helps us test these SDKs by means of HTTP calls while these SDKs run inside a containerized environment.
 
 It's up to each SDK to implement this interface and properly use the SDK. This adds another layer of complexity, but helps us standardize the tests that have to talk to a single HTTP API rather than having to write tests in multiple languages
+
+# Debugging the http requests
+## The easy way
+You can enable ngrep output by declaring the DEBUG environment variable
+DEBUG=true CONFIG=only-valid yarn test
+
+## The hardcore way
+
+You can use wireshark to inspect the communication between the servers and the SDKs as follows while the tests are running:
+
+`docker network ls | grep from-config-test | awk '{ print $1 }' | sort -u | head -n 1 | xargs -i sudo wireshark -k -Y http -i br-{}`
+
+or using ngrep:
+
+`docker network ls | grep from-config-test | awk '{ print $1 }' | sort -u | head -n 1 | xargs -i sudo ngrep -q -W byline -d br-{}`
+
+
+**Breaking the command down:**
+1. `docker network ls` list all docker networks. Since tests open a new network everytime they run, while the tests are running this allow us to see what network the tests are using
+2. `grep from-config-test` we gave a name to the network where the tests run so we can easily get it by this name
+3. `awk '{ print $1 }'` gets the network id
+4. `sort -u | head -n 1` keeps only the first appearence
+5. Options:
+    1. `xargs -i sudo wireshark -k -Y http -i br-{}` takes the id and sends it to wireshark. `-k` jumps directly to the watch screen. `-Y http` applies an http filter. `-i br-{}` specifies the bridge interface which is a combination of br- plus the network id
+    1. `xargs -i sudo ngrep -q -W byline -d br-{}` takes the id and sends it to ngrep. `-W byline` specifies the output. `-d br-{}` specifies the interface which is a combination of br- plus the network id. You can forward the output to a file

--- a/package.json
+++ b/package.json
@@ -2,11 +2,17 @@
   "scripts": {
     "test": "yarn jest",
     "test:debug": "DEBUG=testcontainers* yarn jest",
+
     "test:node": "SDK=node yarn jest",
     "test:java": "SDK=java yarn jest",
     "test:python": "SDK=python yarn jest",
     "test:go": "SDK=go yarn jest",
-    "test:dotnet": "SDK=dotnet yarn jest"
+    "test:dotnet": "SDK=dotnet yarn jest",
+
+    "test:node:valid": "CONFIG=only-valid SDK=node yarn test from-config",
+    "test:java:valid": "CONFIG=only-valid SDK=java yarn test from-config",
+    "test:python:valid": "CONFIG=only-valid SDK=python yarn test from-config",
+    "test:go:valid": "CONFIG=only-valid SDK=go yarn test from-config"
   },
   "devDependencies": {
     "@types/got": "^9.6.12",

--- a/src/tools/ngrep/Dockerfile
+++ b/src/tools/ngrep/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+RUN apk add ngrep bash
+
+WORKDIR /ngrep
+COPY ngrep-with-output /ngrep
+ENTRYPOINT [ "/ngrep/ngrep-with-output" ]

--- a/src/tools/ngrep/ngrep-with-output
+++ b/src/tools/ngrep/ngrep-with-output
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# This scripts wraps ngrep to treat the last parameter as the output file
+set -x
+# ${@:1:$#-1} represents all args except the last one
+# ${@:$#} represents the last argument
+ngrep ${@:1:$#-1} > ${@:$#}


### PR DESCRIPTION
While debugging the latest issue with .Net we noticed it was hard to debug and have eyes on what was going on.

This might not be needed if we just use the Mockserver (which is the idea for the future), but the ability to turn this on is a nice-to-have feature. It's not enabled by default because we don't want this at integration but could be a very useful tool for debugging

The usage is explained in the README file plus other ways of doing something similar.